### PR TITLE
Fix off-by-one error that results in a buffer overwrite

### DIFF
--- a/SieveOfEratosthenes.c
+++ b/SieveOfEratosthenes.c
@@ -8,7 +8,7 @@ void sieveOfEratosthenes(int max) {
 	int i, j;
 	for(i = 2; i < sqrt(max); i++) {
 		if(!primes[i]) {
-			for(j = i*i; j <= max; j+=i) {
+			for(j = i*i; j < max; j+=i) {
 				primes[j] = true;
 			}
 		}


### PR DESCRIPTION
This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md).